### PR TITLE
isort 예제

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
+from pydantic import BaseModel  # Import 순서가 잘못되었습니다.
 from fastapi import FastAPI
-from pydantic import BaseModel
 
 from database.memo import Memo
 


### PR DESCRIPTION
## import 순서 검사
```
from pydantic import BaseModel  # Import 순서가 잘못되었습니다.
from fastapi import FastAPI
from pydantic import BaseModel
```

알파벳 순으로 f -> p 입니다.
고의적으로 pydantic 이 fastapi 앞에 오도록 하면 isort 가 import 순서가 잘못되었음을 알려줍니다.

## 검사 결과
정적분석: 실패
test: 성공
